### PR TITLE
fix getting indexes for tables with special name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Compares two databases and prints SQL commands to modify the first one in order 
 
 **It does NOT execute the statements**. It only prints the statements.
 
-It supports PostgreSQL and MySQL.
+It supports PostgreSQL and MySQL. **(MySQL tests are not working, and need some fixes)**
 
 # Installing
 

--- a/dbdiff.js
+++ b/dbdiff.js
@@ -154,7 +154,7 @@ class DbDiff {
       var desc2 = this._sequenceDescription(sequence2)
 
       if (desc2 !== desc1) {
-        this._safe(`DROP SEQUENCE ${sequenceName};`)
+        this._safe(`DROP SEQUENCE ${sequenceName}; CASCADE`)
         this._safe(desc2)
       }
     })

--- a/dbdiff.js
+++ b/dbdiff.js
@@ -226,7 +226,7 @@ class DbDiff {
     schemaFromDb2.forEach((schema) => {
       var s = this._findSchema(schemaFromDb1, schema)
       if (!s) {
-        this._drop(`CREATE SCHEMA IF NOT EXISTS ${this._quote(schema)};`)
+        this._safe(`CREATE SCHEMA IF NOT EXISTS ${this._quote(schema)};`)
       }
     })
 

--- a/dbdiff.js
+++ b/dbdiff.js
@@ -137,7 +137,7 @@ class DbDiff {
     var diff2 = _.difference(sequenceNames2, sequenceNames1)
 
     diff1.forEach((sequenceName) => {
-      this._safe(`DROP SEQUENCE ${sequenceName} CASCADE;`)
+      this._safe(`DROP SEQUENCE IF EXISTS ${sequenceName} CASCADE;`)
     })
 
     diff2.forEach((sequenceName) => {
@@ -154,7 +154,7 @@ class DbDiff {
       var desc2 = this._sequenceDescription(sequence2)
 
       if (desc2 !== desc1) {
-        this._safe(`DROP SEQUENCE ${sequenceName}; CASCADE`)
+        this._safe(`DROP SEQUENCE IF EXISTS ${sequenceName}; CASCADE`)
         this._safe(desc2)
       }
     })

--- a/dbdiff.js
+++ b/dbdiff.js
@@ -197,8 +197,6 @@ class DbDiff {
       mysql: '`',
       postgres: '"'
     }[this._dialect]
-    this._compareSequences(db1, db2)
-
     var schemaFromDb1 = [...new Set(db1.tables.map((table) => table.schema))]
     var schemaFromDb2 = [...new Set(db2.tables.map((table) => table.schema))]
 
@@ -216,10 +214,12 @@ class DbDiff {
       }
     })
 
+    this._compareSequences(db1, db2)
+
     db1.tables.forEach((table) => {
       var t = this._findTable(db2, table)
       if (!t) {
-        this._drop(`DROP TABLE ${this._fullName(table)};`)
+        this._drop(`DROP TABLE IF EXISTS ${this._fullName(table)};`)
       }
     })
 

--- a/dbdiff.js
+++ b/dbdiff.js
@@ -78,7 +78,7 @@ class DbDiff {
     var tableName = this._fullName(table)
     var keys = index.columns.map((key) => `${this._quote(key)}`).join(',')
     if (this._dialect === 'postgres') {
-      this._safe(`CREATE INDEX ${this._quote(index.name)} ON ${tableName} USING ${index.type} (${keys});`)
+      this._safe(`CREATE INDEX ${this._quote(index.name)} ON ${tableName} USING ${index.type} (${keys})${(index.predicate)? ` WHERE ${index.predicate}` : ''};`)
     } else {
       // mysql
       this._safe(`CREATE INDEX ${this._quote(index.name)} USING ${index.type} ON ${tableName} (${keys});`)

--- a/dbdiff.js
+++ b/dbdiff.js
@@ -163,6 +163,7 @@ class DbDiff {
   _compareConstraints (table1, table2) {
     var tableName = this._fullName(table2)
     table2.constraints.forEach((constraint2) => {
+      var table2Name = this._fullNameFromConstraints(constraint2)
       var constraint1 = table1 && table1.constraints.find((cons) => constraint2.name === cons.name)
       if (constraint1) {
         if (_.isEqual(constraint1, constraint2)) return
@@ -184,7 +185,7 @@ class DbDiff {
           func(`ALTER TABLE ${tableName} ADD CONSTRAINT ${fullName} UNIQUE (${keys});`)
         } else if (constraint2.type === 'foreign') {
           var foreignKeys = constraint2.referenced_columns.map((s) => `${this._quote(s)}`).join(', ')
-          func(`ALTER TABLE ${tableName} ADD CONSTRAINT ${fullName} FOREIGN KEY (${keys}) REFERENCES ${this._quote(constraint2.referenced_table)} (${foreignKeys});`)
+          func(`ALTER TABLE ${tableName} ADD CONSTRAINT ${fullName} FOREIGN KEY (${keys}) REFERENCES ${table2Name} (${foreignKeys});`)
         }
       }
     })
@@ -310,6 +311,11 @@ class DbDiff {
   _fullName (obj) {
     if (obj.schema) return `${this._quote(obj.schema)}.${this._quote(obj.name)}`
     return this._quote(obj.name)
+  }
+
+  _fullNameFromConstraints (obj) {
+    if (obj.schema) return `${this._quote(obj.schema)}.${this._quote(obj.referenced_table)}`
+    return this._quote(obj.referenced_table)
   }
 
   _findTable (db, table) {

--- a/dbdiff.js
+++ b/dbdiff.js
@@ -283,7 +283,9 @@ class DbDiff {
     var constraints = []
     db2.tables.forEach((table) => {
       var t = this._findTable(db1, table)
-      constraints = constraints.concat(this._compareConstraints(t, table))
+      if (t) {
+        constraints = constraints.concat(this._compareConstraints(t, table))
+      }
     })
 
     // execute add constraints after ordering since we should add primary and unqiue keys before foreign ones

--- a/dbdiff.js
+++ b/dbdiff.js
@@ -206,7 +206,7 @@ class DbDiff {
     return constraints
   }
 
-  compareSchemas (db1, db2) {
+  compareSchemas (db1, db2, beautify=true) {
     this.sql = []
     this._dialect = db1.dialect
     this._quotation = {
@@ -250,9 +250,9 @@ class DbDiff {
             var constraint = table.constraints.find((constraints) => constraints.type === 'primary')
             table.constraints.splice(table.constraints.indexOf(constraint), 1)
           }
-          return `\n  ${this._quote(col.name)} ${this._columnDescription(col)}${extra}`
+          return `${beautify ? '\n  ' : ' '}${this._quote(col.name)} ${this._columnDescription(col)}${extra}`
         })
-        this._safe(`CREATE TABLE ${tableName} (${columns.join(',')}\n);`)
+        this._safe(`CREATE TABLE ${tableName} (${columns.join(',')}${beautify ? '\n' : ''});`)
 
         var indexNames2 = this._indexNames(table)
         indexNames2.forEach((indexName) => {

--- a/dbdiff.js
+++ b/dbdiff.js
@@ -137,7 +137,7 @@ class DbDiff {
     var diff2 = _.difference(sequenceNames2, sequenceNames1)
 
     diff1.forEach((sequenceName) => {
-      this._safe(`DROP SEQUENCE ${sequenceName};`)
+      this._safe(`DROP SEQUENCE ${sequenceName} CASCADE;`)
     })
 
     diff2.forEach((sequenceName) => {

--- a/dialects/postgres.js
+++ b/dialects/postgres.js
@@ -81,13 +81,13 @@ class PostgresDialect {
       })
       .then((indexes) => {
         indexes.forEach((index) => {
-          var tableName = index.indrelid.split('.').pop().replace(/^\"+|\"+$/g, '')
+          var tableName = this._unquote(index.indrelid).split('.').pop()
           var table = schema.tables.find((table) => table.name === tableName && table.schema === index.nspname)
           table.indexes.push({
             name: index.indname,
             schema: table.schema,
             type: index.indam,
-            columns: index.indkey_names,
+            columns: index.indkey_names.map((column) => this._unquote(column)),
             predicate: index.indpred,
           })
         })

--- a/dialects/postgres.js
+++ b/dialects/postgres.js
@@ -65,7 +65,7 @@ class PostgresDialect {
               ORDER BY k
             ) AS indkey_names,
             idx.indexprs IS NOT NULL as indexprs,
-            idx.indpred IS NOT NULL as indpred,
+            pg_get_expr(idx.indpred, idx.indrelid) AS indpred,
             ns.nspname
           FROM
             pg_index as idx
@@ -87,7 +87,8 @@ class PostgresDialect {
             name: index.indname,
             schema: table.schema,
             type: index.indam,
-            columns: index.indkey_names
+            columns: index.indkey_names,
+            predicate: index.indpred,
           })
         })
         return client.find(`

--- a/dialects/postgres.js
+++ b/dialects/postgres.js
@@ -81,7 +81,7 @@ class PostgresDialect {
       })
       .then((indexes) => {
         indexes.forEach((index) => {
-          var tableName = index.indrelid.split('.').pop()
+          var tableName = index.indrelid.split('.').pop().replace(/^\"+|\"+$/g, '')
           var table = schema.tables.find((table) => table.name === tableName && table.schema === index.nspname)
           table.indexes.push({
             name: index.indname,

--- a/dialects/postgres.js
+++ b/dialects/postgres.js
@@ -82,6 +82,7 @@ class PostgresDialect {
       .then((indexes) => {
         indexes.forEach((index) => {
           var tableName = this._unquote(index.indrelid).split('.').pop()
+
           var table = schema.tables.find((table) => table.name === tableName && table.schema === index.nspname)
           table.indexes.push({
             name: index.indname,
@@ -123,7 +124,15 @@ class PostgresDialect {
             var substr = description.substring(m + 'REFERENCES'.length)
             i = substr.indexOf('(')
             n = substr.indexOf(')')
-            info.referenced_table = substr.substring(0, i).trim()
+            var full_referenced_table = this._unquote(substr.substring(0, i).trim()) // can contains also schema name as schema.table
+            if (full_referenced_table.includes('.')) {
+              full_referenced_table = full_referenced_table.split('.')
+              info.referenced_table_schema = full_referenced_table[0]
+              info.referenced_table = full_referenced_table[1]
+            } else {
+              info.referenced_table_schema = 'public' // if the name doesn't contains the schema, we use 'public' schema as default
+              info.referenced_table = full_referenced_table
+            }
             info.referenced_columns = substr.substring(i + 1, n).split(',').map((s) => this._unquote(s.trim()))
           }
         })

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kariae/dbdiff",
+  "name": "@zooshgroup/dbdiff",
   "version": "0.5.6",
   "description": "Compares two databases and prints SQL commands to modify the first one in order to match the second one",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@zooshgroup/dbdiff",
-  "version": "0.5.5",
+  "name": "@kariae/dbdiff",
+  "version": "0.5.6",
   "description": "Compares two databases and prints SQL commands to modify the first one in order to match the second one",
   "main": "index.js",
   "scripts": {

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -40,7 +40,7 @@ describe('CLI interface', () => {
       .then(() => exec(`node index.js ${conString1} ${conString2}`))
       .then((result) => {
         var { stdout } = result
-        assert.equal(stdout, 'DROP SEQUENCE "public"."seq_name";\n')
+        assert.equal(stdout, 'DROP SEQUENCE IF EXISTS "public"."seq_name" CASCADE;\n')
       })
   });
 
@@ -52,7 +52,7 @@ describe('CLI interface', () => {
       .then(() => exec(`node index.js -l safe ${conString1} ${conString2}`))
       .then((result) => {
         var { stdout } = result
-        assert.equal(stdout, '-- DROP TABLE "public"."users";\n')
+        assert.equal(stdout, '-- DROP SCHEMA IF EXISTS "public" CASCADE;\n\n-- DROP TABLE IF EXISTS "public"."users" CASCADE;\n')
       })
   })
 

--- a/test/test-postgres.js
+++ b/test/test-postgres.js
@@ -20,7 +20,6 @@ describe('Postgresql', () => {
   })
 
   after('end', () => {
-    // reset public schema
     return utils.end();
   })
 


### PR DESCRIPTION
Postgresql store the tables with a special name (such as a table called `user`) with quotes, in this case, the table `user` is actually stored as `"user"`, you can see this if you create a table with the name `user` and create an index for one of its fields, the `indrelid::regclass` from `pg_index` will return `"user"` and not `user` which breaks `describeDatabase` when it tries to get the table indexes

This a fix for the indexes, but I'm almost sure that this needs to be fixed somewhere else