### PR TITLE
Generating numeric with precision and scale

### DIFF
--- a/dialects/postgres.js
+++ b/dialects/postgres.js
@@ -31,6 +31,8 @@ class PostgresDialect {
               data_type,
               udt_name,
               character_maximum_length,
+              numeric_scale,
+              numeric_precision,
               is_nullable,
               column_default
             FROM
@@ -184,6 +186,8 @@ function dataType(info) {
 
   if (info.character_maximum_length) {
     type = type + '(' + info.character_maximum_length + ')'
+  } else if (info.numeric_precision && info.numeric_scale) {
+    type = type + '(' + info.numeric_precision +',' + info.numeric_scale +')'
   }
   return type
 }

--- a/dialects/postgres.js
+++ b/dialects/postgres.js
@@ -186,7 +186,7 @@ function dataType(info) {
 
   if (info.character_maximum_length) {
     type = type + '(' + info.character_maximum_length + ')'
-  } else if (info.numeric_precision && info.numeric_scale) {
+  } else if (info.data_type ==='numeric' && info.numeric_precision) {
     type = type + '(' + info.numeric_precision +',' + info.numeric_scale +')'
   }
   return type


### PR DESCRIPTION
Postgres: generates numeric types with precision and scale, like `NUMERIC(15, 10)` instead of just `NUMERIC` if specified. Added new tests for this case. 
If no precision specified, behaves as before.
Thank you!